### PR TITLE
Add ability to update quantity & override resource mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ The second item is the value that will be sent to Lightspeed. It also accepts [m
 
 In case of a relationship, the first value is the local foreign key.
 The second, is the related primary key.
+
+You can also use numeric values to override the resource mapping completely. This may be useful if you are wanting to send an ID that you might not be storing in your DB, such as your Shop ID.
     
 ```php
 public function getArchivedAttribute(): bool

--- a/src/Actions/GenerateRetailPayloadAction.php
+++ b/src/Actions/GenerateRetailPayloadAction.php
@@ -23,14 +23,12 @@ class GenerateRetailPayloadAction
             foreach ($resourceMapping as $apiColumn => $attribute) {
                 $localAttribute = $attribute;
                 $value = $attribute;
-
                 // map the "dirty" column with the mutated value
                 if (is_array($attribute)) {
                     $localAttribute = head($attribute);
                     $value = last($attribute);
                 }
-
-                if ($forcePayload === false && ! in_array($localAttribute, $model->lsForceSyncFields ?? [], true) && $model->isDirty($localAttribute) === false) {
+                if (!is_numeric($value) && $forcePayload === false && ! in_array($localAttribute, $model->lsForceSyncFields ?? [], true) && $model->isDirty($localAttribute) === false) {
                     continue;
                 }
 
@@ -60,7 +58,9 @@ class GenerateRetailPayloadAction
                 } else {
                     $resourceColumnValue = $model->$value;
                 }
-
+                if(is_numeric($value)) {
+                    $resourceColumnValue = $value;
+                }
                 // default mapping -> the order of these parameters is important
                 $payloads[$resource]['model'] = $model->withoutRelations();
                 $payloads[$resource]['resource'] = $resource;

--- a/src/Services/Lightspeed/ResourceItem.php
+++ b/src/Services/Lightspeed/ResourceItem.php
@@ -28,6 +28,8 @@ class ResourceItem extends Resource
     public static string $defaultCost = 'defaultCost';
     public static string $note = 'Note';
     public static string $customFields = 'CustomFieldValues';
+    public static string $shopId = 'shopId';
+    public static string $defaultQty = 'defaultyQty';
 
     /**
      * @throws \TimothyDC\LightspeedRetailApi\Exceptions\LightspeedRetailException
@@ -67,7 +69,7 @@ class ResourceItem extends Resource
     protected function formatPayload(array $payload, int $id = null): array
     {
         $payload = $this->adjustPricePayload($payload);
-
+        $payload = $this->adjustQuantityPayload($payload);
         return $payload;
     }
 
@@ -81,6 +83,21 @@ class ResourceItem extends Resource
             ];
 
             unset($payload[self::$defaultPrice]);
+        }
+
+        return $payload;
+    }
+
+    private function adjustQuantityPayload(array $payload): array
+    {
+        if (array_key_exists(self::$shopId, $payload) && array_key_exists(self::$defaultQty, $payload)) {
+            $payload['ItemShops']['ItemShop'][] = [
+                'qoh' => $payload[self::$defaultQty],
+                'shopID' => $payload[self::$shopId],
+            ];
+
+            unset($payload[self::$defaultQty]);
+            unset($payload[self::$shopId]);
         }
 
         return $payload;


### PR DESCRIPTION
Pretty basic functionality at the moment, but this will allow a user to add a default quantity to their products.

This requires a ShopID to be present, so I've also added the ability to override the resource mapping so people can provide a numeric ID here without saving it to the database. I'm open to any ideas on how this could be improved, perhaps we should use a callback function instead for overriding?


