### PR TITLE
Resource Item as Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ $categories = LightspeedRetailApi::api()->category()->get(20);
 
 // same as above, but better
 $categories = LightspeedRetailApi::api()->category()->first(20);
+
+// some resources support custom arguments
+$label = LightspeedRetailApi::api()->itemAsLabel()->getLabelById('1', 'ItemLabel', true);
 ```
 
 Note that not all [resources][ls-added-resources] are added (yet). Feel free to add them yourself via a pull request!
@@ -185,6 +188,8 @@ The second item is the value that will be sent to Lightspeed. It also accepts [m
 
 In case of a relationship, the first value is the local foreign key.
 The second, is the related primary key.
+
+You can also use numeric values to override the resource mapping completely. This may be useful if you are wanting to send an ID that you might not be storing in your DB, such as your Shop ID.
     
 ```php
 public function getArchivedAttribute(): bool

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ The second item is the value that will be sent to Lightspeed. It also accepts [m
 In case of a relationship, the first value is the local foreign key.
 The second, is the related primary key.
 
-You can also use numeric values to override the resource mapping completely. This may be useful if you are wanting to send an ID that you might not be storing in your DB, such as your Shop ID.
     
 ```php
 public function getArchivedAttribute(): bool

--- a/src/Services/ApiClient.php
+++ b/src/Services/ApiClient.php
@@ -111,7 +111,7 @@ class ApiClient
 
         $response = $responseObject->json();
 
-        //If we're requesting HTMl, just return our HTML
+        //If we're requesting HTML, just return our HTML
         if($additionalHeaders['Content-Type'] === 'text/html') {
             return $responseObject->body();
         }

--- a/src/Services/ApiClient.php
+++ b/src/Services/ApiClient.php
@@ -112,7 +112,7 @@ class ApiClient
         $response = $responseObject->json();
 
         //If we're requesting HTML, just return our HTML
-        if($additionalHeaders['Content-Type'] === 'text/html') {
+        if(isset($additionalHeaders['Content-Type']) &&$additionalHeaders['Content-Type'] === 'text/html') {
             return $responseObject->body();
         }
         // unstructured way of requesting the "Account" resource

--- a/src/Services/ApiClient.php
+++ b/src/Services/ApiClient.php
@@ -62,11 +62,6 @@ class ApiClient
         }
     }
 
-    public function getAccountId(): int
-    {
-        return $this->tokenRepository->getAccountId();
-    }
-
     public function isConfigured(): bool
     {
         return $this->tokenRepository->exists();

--- a/src/Services/Lightspeed/ResourceItemAsLabel.php
+++ b/src/Services/Lightspeed/ResourceItemAsLabel.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace TimothyDC\LightspeedRetailApi\Services\Lightspeed;
+
+use Illuminate\Support\Collection;
+use TimothyDC\LightspeedRetailApi\Resource;
+use TimothyDC\LightspeedRetailApi\Services\ApiClient;
+
+class ResourceItemAsLabel extends Resource
+{
+    public static string $resource = 'DisplayTemplate/ItemAsLabel';
+    public string $primaryKey = 'labelID';
+
+    public static string $itemId = 'itemId';
+    public static string $template = 'template';
+
+    public function getLabelById(int $id, string $template = null, $asHtml = false)
+    {
+        $extension = ($asHtml) ? 'html' : 'json';
+        $response = $this->client->get(
+            self::$resource, $id,
+            [
+                'template' => $template,
+            ],
+            [
+                'Accept' => '*/*',
+                'Content-Type' => 'text/' . $extension
+            ],
+            $extension,
+            'Label'
+        );
+
+        return $response;
+    }
+}

--- a/src/Traits/RetailResources.php
+++ b/src/Traits/RetailResources.php
@@ -7,6 +7,7 @@ use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceAccount;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceCategory;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceCustomer;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceItem;
+use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceItemAsLabel;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceManufacturer;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceSale;
 use TimothyDC\LightspeedRetailApi\Services\Lightspeed\ResourceVendor;
@@ -31,6 +32,11 @@ trait RetailResources
     public function item(): ResourceItem
     {
         return new ResourceItem($this);
+    }
+
+    public function itemAsLabel(): ResourceItemAsLabel
+    {
+        return new ResourceItemAsLabel($this);
     }
 
     public function manufacturer(): ResourceManufacturer


### PR DESCRIPTION
- Allows a user to get a label using the [DisplayTemplate Label](https://developers.lightspeedhq.com/retail/endpoints/DisplayTemplate-Label) endpoint
- Updates the ApiClient to support header and file type overrides for get requests, as well as more accommodation for our Item Label resource. At some point, it would be good to update the other request functions to be in line with these updates.
- Would appreciate feedback on how this could all be improved